### PR TITLE
Update `typescript-eslint-parser` to work with recent TypeScript versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,12 +5,13 @@ var Walker = require('node-source-walk');
  * Extracts the dependencies of the supplied TypeScript module
  *
  * @param  {String|Object} src - File's content or AST
+ * @param  {Object} options - options to pass to the parser
  * @return {String[]}
  */
-module.exports = function(src) {
-  var walker = new Walker({
-    parser: Parser
-  });
+module.exports = function(src, options = {}) {
+  options.parser = Parser;
+
+  var walker = new Walker(options);
 
   var dependencies = [];
 

--- a/index.js
+++ b/index.js
@@ -23,11 +23,22 @@ module.exports = function(src, options = {}) {
     return dependencies;
   }
 
+  var importSpecifiers = {};
   walker.walk(src, function(node) {
     switch (node.type) {
       case 'ImportDeclaration':
         if (node.source && node.source.value) {
           dependencies.push(node.source.value);
+
+          node.specifiers.forEach((specifier) => {
+            var specifierValue = {
+              isDefault: specifier.type === 'ImportDefaultSpecifier',
+              name: specifier.local.name
+            };
+            importSpecifiers[node.source.value]
+              ? importSpecifiers[node.source.value].push(specifierValue)
+              : importSpecifiers[node.source.value] = [specifierValue];
+          });
         }
         break;
       case 'ExportNamedDeclaration':
@@ -45,6 +56,7 @@ module.exports = function(src, options = {}) {
         return;
     }
   });
+  options.importSpecifiers = importSpecifiers;
 
   return dependencies;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1369,6 +1369,11 @@
         "type-check": "0.3.2"
       }
     },
+    "lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
+    },
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
@@ -1580,6 +1585,11 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -1595,40 +1605,13 @@
         "prelude-ls": "1.1.2"
       }
     },
-    "typescript": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.0.10.tgz",
-      "integrity": "sha1-zN1O2G/VVQpAcQGggUAS4bP6w90="
-    },
     "typescript-eslint-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-1.0.2.tgz",
-      "integrity": "sha1-/Sq6zy7j2Tgqs+RJyHYra+rk0Nc=",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-8.0.1.tgz",
+      "integrity": "sha1-6MrFN9mW4Ww9uw18TVCXmeZ6/gw=",
       "requires": {
-        "lodash.unescape": "4.0.0",
-        "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "lodash.unescape": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.0.tgz",
-          "integrity": "sha1-Nt6/xJK4FHhHHvl0zTeD4gLrbO8=",
-          "requires": {
-            "lodash.tostring": "4.1.4"
-          },
-          "dependencies": {
-            "lodash.tostring": {
-              "version": "4.1.4",
-              "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.4.tgz",
-              "integrity": "sha1-Vgwn0fjq3eA8LM4Zj+9cAx2CmPs="
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        }
+        "lodash.unescape": "4.0.1",
+        "semver": "5.4.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1605,10 +1605,15 @@
         "prelude-ls": "1.1.2"
       }
     },
+    "typescript": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
+      "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE="
+    },
     "typescript-eslint-parser": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-8.0.1.tgz",
-      "integrity": "sha1-6MrFN9mW4Ww9uw18TVCXmeZ6/gw=",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-9.0.0.tgz",
+      "integrity": "sha512-A81zCm5N8DVwkIOycAGTZTMrd3sthpyxCVpaA4+XiK1gG/G8xKLPKwDnlxciurNUOc7Z85ji9VvIi8g+ihRjEw==",
       "requires": {
         "lodash.unescape": "4.0.1",
         "semver": "5.4.1"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/pahen/detective-typescript",
   "dependencies": {
     "node-source-walk": "3.2.0",
-    "typescript-eslint-parser": "^8.0.0"
+    "typescript": "^2.6.1",
+    "typescript-eslint-parser": "^9.0.0"
   },
   "devDependencies": {
     "eslint": "3.14.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "homepage": "https://github.com/pahen/detective-typescript",
   "dependencies": {
     "node-source-walk": "3.2.0",
-    "typescript": "^2.5.0",
     "typescript-eslint-parser": "^8.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "homepage": "https://github.com/pahen/detective-typescript",
   "dependencies": {
     "node-source-walk": "3.2.0",
-    "typescript": "2.0.10",
-    "typescript-eslint-parser": "1.0.2"
+    "typescript": "^2.5.0",
+    "typescript-eslint-parser": "^8.0.0"
   },
   "devDependencies": {
     "eslint": "3.14.0",


### PR DESCRIPTION
I was unable to get this working on my TypeScript 2.6.2 based project.

By using this fork everything worked fine.

Therefore I think this should be merged.