### PR TITLE
Fix JSX support

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,9 @@ const Walker = require('node-source-walk');
  * @param  {String|Object} src - File's content or AST
  * @return {String[]}
  */
-module.exports = function(src) {
-  const walker = new Walker({
-    parser: Parser
-  });
+module.exports = function(src, options = {}) {
+  options.parser = Parser;
+  const walker = new Walker(options);
 
   const dependencies = [];
 

--- a/test/test.js
+++ b/test/test.js
@@ -88,8 +88,14 @@ describe('detective-typescript', () => {
       detective(`import foo from 'foo'; var baz = <baz>bar;`);
     });
   });
-  
-  it('does not throw with JSX in a module', () => {
+
+  it('throws with JSX in a module and !ecmaFeatures.jsx', () => {
+    assert.throws(() => {
+      detective(`import Foo from 'Foo'; var foo = <Foo/>`);
+    });
+  });
+
+  it('does not throw with JSX in a module and ecmaFeatures.jsx', () => {
     assert.doesNotThrow(() => {
       detective(`import Foo from 'Foo'; var foo = <Foo/>`, { ecmaFeatures: { jsx: true } });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -83,7 +83,7 @@ describe('detective-typescript', () => {
     }, Error, 'src not given');
   });
 
-  it('does not throw with jsx in a module', () => {
+  it('does not throw with angle bracket type assertions in a module', () => {
     assert.doesNotThrow(() => {
       detective('import foo from \'foo\'; var baz = <baz>bar;');
     });

--- a/test/test.js
+++ b/test/test.js
@@ -85,7 +85,13 @@ describe('detective-typescript', () => {
 
   it('does not throw with angle bracket type assertions in a module', () => {
     assert.doesNotThrow(() => {
-      detective('import foo from \'foo\'; var baz = <baz>bar;');
+      detective(`import foo from 'foo'; var baz = <baz>bar;`);
+    });
+  });
+  
+  it('does not throw with JSX in a module', () => {
+    assert.doesNotThrow(() => {
+      detective(`import Foo from 'Foo'; var foo = <Foo/>`, { ecmaFeatures: { jsx: true } });
     });
   });
 });


### PR DESCRIPTION
I was seeing errors parsing JSX expressions (via `precinct`). The reason is that `typescript-eslint-parser` requires some extra options to be passed to indicate a file contains JSX.

I've added some tests, and updated one existing one. Now it's possible to parse JSX by passing the necessary options (`{ ecmaFeatures:  { jsx: true } }`). If this is acceptable, my plan is to add filetype detection (based on the `.tsx` extension) to `precinct` and pass the necessary options there.