### PR TITLE
Add `tsx` export with enables JSX by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,3 +48,10 @@ module.exports = function(src, options = {}) {
 
   return dependencies;
 };
+
+module.exports.tsx = function(src, options) {
+  options = Object.assign({
+    ecmaFeatures: Object.assign(options.ecmaFeatures, { jsx: true })
+  }, options);
+  module.exports(src, options);
+};


### PR DESCRIPTION
Hi again @pahen! After [some discussion](https://github.com/dependents/node-precinct/pull/48#discussion_r217885687) with @mrjoelkemp on my `node-precinct` PR, I think it would be a much cleaner solution for everyone if we add this second export here. What do you think?