### PR TITLE
Detect dynamic imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,11 @@ module.exports = function(src, options = {}) {
 
   walker.walk(src, function(node) {
     switch (node.type) {
+      case 'Import':
+        if (node.parent && node.parent.type === 'CallExpression' && node.parent.arguments.length) {
+          dependencies.push(node.parent.arguments[0].value);
+        }
+        break;
       case 'ImportDeclaration':
         if (node.source && node.source.value) {
           dependencies.push(node.source.value);

--- a/test/test.js
+++ b/test/test.js
@@ -61,6 +61,12 @@ describe('detective-typescript', () => {
     assert(deps[0] === 'foo');
   });
 
+  it('handles dynamic imports', () => {
+    const deps = detective('import("foo");');
+    assert(deps.length === 1);
+    assert(deps[0] === 'foo');
+  });
+
   it('retrieves dependencies from modules using "export ="', () => {
     const deps = detective('import foo = require("mylib");');
     assert(deps.length === 1);


### PR DESCRIPTION
Hi,
While using https://github.com/dependents/node-dependency-tree to collect dependencies of webpack bundles, I noticed that the dynamic imports were not followed, a similar issue to the one fixed here in the es6 detective: https://github.com/dependents/node-ast-module-types/pull/14.
This branch fixes a similar issue for ts and tsx modules.
Thanks in advance for your consideration and feedback!