### PR TITLE
Return dependencies specified in type annotations

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,11 @@ module.exports = function(src, options = {}) {
           dependencies.push(node.expression.value);
         }
         break;
+      case 'TSImportType':
+        if (node.parameter.type === 'TSLiteralType') {
+          dependencies.push(node.parameter.literal.value);
+        }
+        break;
       default:
         return;
     }

--- a/test/test.js
+++ b/test/test.js
@@ -119,4 +119,10 @@ describe('detective-typescript', () => {
       assert.equal(results[0], 'Foo');
     });
   });
+
+  it('parses out type annotation imports', () => {
+    const deps = detective('const x: typeof import("foo") = 0;');
+    assert(deps.length === 1);
+    assert(deps[0] === 'foo');
+  });
 });


### PR DESCRIPTION
thanks for the great module! i added support for `import()` appearing in type annotations.