### PR TITLE
Add skipTypeImports option

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,14 +11,15 @@ const Walker = require('node-source-walk');
  */
 module.exports = function(src, options = {}) {
 
+  const walkerOptions = Object.assign({}, options, {parser: Parser});
+
   // Determine whether to skip "type-only" imports
   // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html#import-types
   const skipTypeImports = Boolean(options.skipTypeImports);
   // Remove skipTypeImports option, as this option may not be recognized by the walker/parser
-  delete options.skipTypeImports;
+  delete walkerOptions.skipTypeImports;
 
-  options.parser = Parser;
-  const walker = new Walker(options);
+  const walker = new Walker(walkerOptions);
 
   const dependencies = [];
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,13 @@ const Walker = require('node-source-walk');
  * @return {String[]}
  */
 module.exports = function(src, options = {}) {
+
+  // Determine whether to skip "type-only" imports
+  // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html#import-types
+  const skipTypeImports = Boolean(options.skipTypeImports);
+  // Remove skipTypeImports option, as this option may not be recognized by the walker/parser
+  delete options.skipTypeImports;
+
   options.parser = Parser;
   const walker = new Walker(options);
 
@@ -47,7 +54,7 @@ module.exports = function(src, options = {}) {
         }
         break;
       case 'TSImportType':
-        if (node.parameter.type === 'TSLiteralType') {
+        if (!skipTypeImports && node.parameter.type === 'TSLiteralType') {
           dependencies.push(node.parameter.literal.value);
         }
         break;

--- a/test/test.js
+++ b/test/test.js
@@ -125,4 +125,10 @@ describe('detective-typescript', () => {
     assert(deps.length === 1);
     assert(deps[0] === 'foo');
   });
+
+  it('does not count type annotation imports if the skipTypeImports option is enabled', () => {
+    const deps = detective('const x: typeof import("foo") = 0;', {skipTypeImports: true});
+    assert(deps.length === 0);
+  });
+
 });


### PR DESCRIPTION
Resolves the `detective-typescript` changes required for https://github.com/pahen/madge/issues/217.

This will mean that [type-only imports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html#import-types) aren't counted as dependencies when the `skipTypeImports` option is used.