### PR TITLE
chore: upgrade dependence of typescript for support newest ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   "license": "MIT",
   "homepage": "https://github.com/pahen/detective-typescript",
   "dependencies": {
-    "@typescript-eslint/typescript-estree": "^1.9.0",
+    "@typescript-eslint/typescript-estree": "^2.3.3",
     "node-source-walk": "^4.2.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.6.4"
   },
   "devDependencies": {
     "eslint": "^5.12.0",


### PR DESCRIPTION
upgrade the dependence of ts for solve this problem: [madge](https://github.com/pahen/madge/issues/221)

``` bash
Hi, there is no support for typescript version 3.6.2. Console output:

SUPPORTED TYPESCRIPT VERSIONS: >=3.2.1 <3.6.0
```