### PR TITLE
Add support for mixed imports in TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ var dependencies = detective(mySourceCode);
 
 ```
 
+### Options
+
+- `skipTypeImports` (default: false) - Skips imports that only imports types
+- `mixedImports`: (default: false) - Include CJS imports in dependency list
+
 #### License
 
 MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,6 +124,11 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "ast-module-types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-2.5.0.tgz",
+      "integrity": "sha512-dP6vhvatex3Q+OThhvcyGRvHn4noQBg1b8lCNKUAFL05up80hr2pAExveU3YQNDGMhfNPhQit/vzIkkvBPbSXw=="
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/pahen/detective-typescript",
   "dependencies": {
     "@typescript-eslint/typescript-estree": "^2.4.0",
+    "ast-module-types": "^2.5.0",
     "node-source-walk": "^4.2.0",
     "typescript": "^3.6.4"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -131,4 +131,9 @@ describe('detective-typescript', () => {
     assert(deps.length === 0);
   });
 
+  it('supports CJS when mixedImports is true', () => {
+    const deps = detective('const foo = require("foobar")', { mixedImports: true });
+    assert(deps.length === 1);
+    assert(deps[0] === 'foobar');
+  })
 });


### PR DESCRIPTION
This is needed to support mixed imports in precinct > dependency-tree > madge:
https://github.com/dependents/node-precinct/issues/65

The code was basically copied from `detective-cjs`: https://github.com/dependents/node-detective-cjs/blob/fcaae512bd03f0389354a694141a248a4f510425/index.js