### PR TITLE
Add support for runtime dynamic imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ var dependencies = detective(mySourceCode);
 
 - `skipTypeImports` (default: false) - Skips imports that only imports types
 - `mixedImports`: (default: false) - Include CJS imports in dependency list
+- `runtimeDynamicImports`: (default: false) - Include dynamic imports that are imported at runtime
 
 #### License
 

--- a/index.js
+++ b/index.js
@@ -24,6 +24,9 @@ module.exports = function(src, options = {}) {
   const mixedImports = Boolean(options.mixedImports);
   delete walkerOptions.mixedImports;
 
+  const runtimeDynamicImports = Boolean(options.runtimeDynamicImports);
+  delete walkerOptions.runtimeDynamicImports;
+
   const walker = new Walker(walkerOptions);
 
   const dependencies = [];
@@ -41,6 +44,8 @@ module.exports = function(src, options = {}) {
       case 'ImportExpression':
         if (node.parent && node.parent.type === 'ExpressionStatement' && node.parent.expression.source.type === 'Literal') {
           dependencies.push(node.parent.expression.source.value);
+        } else if (runtimeDynamicImports && node.source && node.source.value) {
+          dependencies.push(node.source.value);
         }
         break;
       case 'ImportDeclaration':

--- a/test/test.js
+++ b/test/test.js
@@ -67,6 +67,17 @@ describe('detective-typescript', () => {
     assert(deps[0] === 'foo');
   });
 
+  it('handles runtime dynamic imports with option', () => {
+    const deps = detective('() => import("foo");', { runtimeDynamicImports: true });
+    assert(deps.length === 1);
+    assert(deps[0] === 'foo');
+  });
+
+  it('does not include runtime dynamic imports without option', () => {
+    const deps = detective('() => import("foo");');
+    assert(deps.length === 0);
+  });
+
   it('retrieves dependencies from modules using "export ="', () => {
     const deps = detective('import foo = require("mylib");');
     assert(deps.length === 1);


### PR DESCRIPTION
Thanks for the great package! I'm using this via dependency-tree and would like to include dependencies that are imported at runtime. Since it's a bigger change I decided to make it optional but could go either way on that. Happy to make any requested changes. Thanks!