### PR TITLE
feat: move typescript to an optional peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1391,9 +1391,10 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,16 @@
   "dependencies": {
     "@typescript-eslint/typescript-estree": "^4.8.2",
     "ast-module-types": "^2.7.1",
-    "node-source-walk": "^4.2.0",
-    "typescript": "^3.9.7"
+    "node-source-walk": "^4.2.0"
   },
   "devDependencies": {
     "eslint": "^7.14.0",
-    "mocha": "^8.2.1"
+    "mocha": "^8.2.1",
+    "typescript": "~4.1.5"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
This mirrors how typescript-estree depends on typescript:

https://github.com/typescript-eslint/typescript-eslint/blob/946ee3b68823a48fad2cb7b99589e56a68fb11e3/packages/typescript-estree/package.json#L69-L73

typescript-estree prints a warning if it doesn't like the currently
installed typescript version, which seems like good behaviour.

This has two advantages:

1) We don't have to update this library every time there's a new TS release
2) Better alignment with what the user is actually using.

NB: Typescript don't do semver, so the gap from 3.9 to 4.0 is the same as the gap from 4.0 to 4.1 or 3.8 to 3.9.
NB: `npm 7` will install peer dependencies by default again.